### PR TITLE
Add toPostgres method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,8 @@ export class Range<T> {
 
   containsPoint (point: T): boolean;
   containsRange (range: Range<T>): boolean;
+
+  toPostgres (prepareValue: (value: any) => string): string;
 }
 
 export function parse(input: string): Range<string>;

--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ class Range {
       (!range.hasUpperBound() || this.containsPoint(range.upper))
     )
   }
+
+  toPostgres (prepareValue) {
+    return serialize(this, prepareValue);
+  }
 }
 
 /**


### PR DESCRIPTION
node-postgres has undocumented support for custom serialization if an object has a `toPostgres` method on it. 

This PR adds such a function to the Range class so that you can give an instance as a parameter to node-postgres (or Knex or whatever might sit on top) without having to explicitly serialize it. 

Since node-pg-types uses this library per default, it felt like the right place to add this so that it works both ways out of the box. Let me know what you think!