### PR TITLE
Add range functions to better align with psql 9.1 (issue 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ rng.containsPoint(4)
 // => true
 rng.containsRange(range.parse('[1,2]', x => parseInt(x)))
 // => true
+rng.strictlyLeftOf(range.parse('[6,7]', x => parseInt(x)))
+// => true
+rng.strictlyRightOf(range.parse('[-10,-1]', x => parseInt(x)))
+// => true
+rng.overlaps(range.parse('[4,7]', x => parseInt(x)))
+// => true
+rng.adjacentTo(range.parse('(5,6]', x => parseInt(x)))
+// => true
 
 range.parse('empty').isEmpty()
 // => true

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ rng.containsPoint(4)
 // => true
 rng.containsRange(range.parse('[1,2]', x => parseInt(x)))
 // => true
+rng.extendsLeftOf(range.parse('[1,10]', x => parseInt(x)))
+// => true
+rng.extendsRightOf(range.parse('[0,3]', x => parseInt(x)))
+// => true
 rng.strictlyLeftOf(range.parse('[6,7]', x => parseInt(x)))
 // => true
 rng.strictlyRightOf(range.parse('[-10,-1]', x => parseInt(x)))
@@ -42,6 +46,13 @@ rng.adjacentTo(range.parse('(5,6]', x => parseInt(x)))
 
 range.parse('empty').isEmpty()
 // => true
+
+range.union('[5,10]')
+// => [0,10]
+range.intersection('[3,10]')
+// => [3,5)
+range.difference('[3,10]')
+// => [0,3)
 
 range.serialize(new range.Range(0, 5))
 // => '(0,5)'

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,8 @@ export class Range<T> {
   hasLowerBound (): boolean;
   hasUpperBound (): boolean;
 
+  equals (range: Range<T>): Range<T>;
+
   containsPoint (point: T): boolean;
   containsRange (range: Range<T>): boolean;
   strictlyRightOf (range: Range<T>): boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,13 @@ export class Range<T> {
 
   containsPoint (point: T): boolean;
   containsRange (range: Range<T>): boolean;
+  
+  strictlyRightOf (range: Range<T>): boolean;
+  strictlyLeftOf (range: Range<T>): boolean;
+
+  adjacentTo (range: Range<T>): boolean;
+
+  overlaps (range: Range<T>): boolean;
 
   toPostgres (prepareValue: (value: any) => string): string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,13 +18,16 @@ export class Range<T> {
 
   containsPoint (point: T): boolean;
   containsRange (range: Range<T>): boolean;
-  
   strictlyRightOf (range: Range<T>): boolean;
   strictlyLeftOf (range: Range<T>): boolean;
-
+  extendsRightOf (range: Range<T>): boolean;
+  extendsLeftOf (range: Range<T>): boolean;
   adjacentTo (range: Range<T>): boolean;
-
   overlaps (range: Range<T>): boolean;
+
+  union (range: Range<T>): Range<T>;
+  intersection (range: Range<T>): Range<T>;
+  difference (range: Range<T>): Range<T>;
 
   toPostgres (prepareValue: (value: any) => string): string;
 }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,15 @@ class Range {
   }
 
   /**
+   * @param {Range} range
+   */
+  equals (range) {
+    return this.lower === range.lower
+      && this.upper === range.upper
+      && this.mask === range.mask
+  }
+
+  /**
    * @param {number} flag
    */
   hasMask (flag) {

--- a/index.js
+++ b/index.js
@@ -86,6 +86,56 @@ class Range {
     )
   }
 
+  /**
+   * @param {Range} range
+   */
+  strictlyRightOf (range) {
+    if (
+      range.isEmpty()
+      || this.isEmpty()
+      || range.hasMask(RANGE_UB_INF)
+      || this.hasMask(RANGE_LB_INF)
+    ) {
+      return false
+    } else if (range.hasMask(RANGE_UB_INC) && this.hasMask(RANGE_LB_INC)) {
+      return this.lower > range.upper 
+    }
+    return this.lower >= range.upper 
+  }
+
+  /**
+   * @param {Range} range
+   */
+  strictlyLeftOf (range) {
+    if (
+      range.isEmpty()
+      || this.isEmpty()
+      || range.hasMask(RANGE_LB_INF)
+      || this.hasMask(RANGE_UB_INF)) {
+      return false
+    } else if (range.hasMask(RANGE_LB_INC) && this.hasMask(RANGE_UB_INC)) {
+      return this.upper < range.lower 
+    }
+    return this.upper <= range.lower 
+  }
+
+  /**
+   * @param {Range} range
+   */
+  overlaps (range) {
+    return !(this.strictlyRightOf(range) || this.strictlyLeftOf(range))
+  }
+
+  /**
+   * @param {Range} range
+   */
+  adjacentTo (range) {
+    return (
+      (this.upper == range.lower && !(this.hasMask(RANGE_UB_INC) && range.hasMask(RANGE_LB_INC))) ||
+      (this.lower == range.upper && !(this.hasMask(RANGE_LB_INC) && range.hasMask(RANGE_UB_INC)))
+    )
+  }
+
   toPostgres (prepareValue) {
     return serialize(this, prepareValue)
   }

--- a/index.test.js
+++ b/index.test.js
@@ -100,6 +100,9 @@ describe('Range: boolean methods', function () {
   t(parse('[1, 10)', x => parseInt(x)).containsRange(parse('[1, 3]', x => parseInt(x))), true, '[1, 10).containsRange(\'[1, 3]\') is true')
   t(parse('[1, 10)', x => parseInt(x)).containsRange(parse('[-1, 3]', x => parseInt(x))), false, '[1, 10).containsRange(\'[-1, 3]\') is false')
 
+  t(parse('[1, 10)', x => parseInt(x)).equals(parse('[1, 10)', x => parseInt(x))), true, '[1, 10).equals(\'[1, 10)\') is true')
+  t(parse('[1, 10]', x => parseInt(x)).equals(parse('[1, 10)', x => parseInt(x))), false, '[1, 10].equals(\'[1, 10)\') is false')
+
   t(parse('empty', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), false, 'empty.strictlyLeftOf(\'[9, 11)\') is false')
   t(parse('[5, 6)', x => parseInt(x)).strictlyLeftOf(parse('empty', x => parseInt(x))), false, '[5, 6).strictlyLeftOf(\'empty\') is false')
   t(parse('[5, 6)', x => parseInt(x)).strictlyLeftOf(parse('(, 11)', x => parseInt(x))), false, '[5,6).strictlyLeftOf(\'(, 11)\') is false')

--- a/index.test.js
+++ b/index.test.js
@@ -96,6 +96,35 @@ describe('roundtrip', function () {
 describe('Range', function () {
   t(parse('[1, 10)', x => parseInt(x)).containsPoint(5), true, '[1, 10).containsPoint(5) is true')
   t(parse('[1, 10)', x => parseInt(x)).containsPoint(-5), false, '[1, 10).containsPoint(-5) is false')
+
   t(parse('[1, 10)', x => parseInt(x)).containsRange(parse('[1, 3]', x => parseInt(x))), true, '[1, 10).containsRange(\'[1, 3]\') is true')
   t(parse('[1, 10)', x => parseInt(x)).containsRange(parse('[-1, 3]', x => parseInt(x))), false, '[1, 10).containsRange(\'[-1, 3]\') is false')
+
+  t(parse('empty', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), false, 'empty.strictlyLeftOf(\'[9, 11)\') is false')
+  t(parse('[5, 6)', x => parseInt(x)).strictlyLeftOf(parse('empty', x => parseInt(x))), false, '[5, 6).strictlyLeftOf(\'empty\') is false')
+  t(parse('[5, 6)', x => parseInt(x)).strictlyLeftOf(parse('(, 11)', x => parseInt(x))), false, '[5,6).strictlyLeftOf(\'(, 11)\') is false')
+  t(parse('[5,)', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), false, '[5,).strictlyLeftOf(\'[9, 11)\') is false')
+  t(parse('[5, 9)', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), true, '[5, 9).strictlyLeftOf(\'[9, 11)\') is true')
+  t(parse('[5, 9]', x => parseInt(x)).strictlyLeftOf(parse('(9, 11)', x => parseInt(x))), true, '[5, 9].strictlyLeftOf(\'[(9, 11)\') is true')
+  t(parse('[5, 9]', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), false, '[5, 9].strictlyLeftOf(\'[9, 11)\') is false')
+  t(parse('[5, 10)', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), false, '[5, 10).strictlyLeftOf(\'[9, 11)\') is false')
+
+  t(parse('empty', x => parseInt(x)).strictlyRightOf(parse('[5, 10)', x => parseInt(x))), false, 'empty.strictlyRightOf(\'[5, 10)\') is false')
+  t(parse('[5, 10)', x => parseInt(x)).strictlyRightOf(parse('empty', x => parseInt(x))), false, '[5, 10).strictlyRightOf(\'empty\') is false')
+  t(parse('[20, 30)', x => parseInt(x)).strictlyRightOf(parse('(5,)', x => parseInt(x))), false, '[20, 30).strictlyLeftOf(\'(5,)\') is false')
+  t(parse('(,30)', x => parseInt(x)).strictlyRightOf(parse('[5, 10)', x => parseInt(x))), false, '(, 30).strictlyLeftOf(\'[5, 10)\') is false')
+  t(parse('[30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30)', x => parseInt(x))), true, '[30, 40).strictlyRightOf(\'[20, 30)\') is true')
+  t(parse('(30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), true, '(30, 40).strictlyRightOf(\'[20, 30]\') is true')
+  t(parse('[30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), false, '[30, 40).strictlyRightOf(\'[20, 30]\') is false')
+  t(parse('[50, 60)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), true, '[50, 60).strictlyRightOf(\'[20, 30]\') is false')
+
+  t(parse('[5, 10)', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), false, '[5, 10).overlaps(\'[10, 11]\') is false')
+  t(parse('[5, 10]', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), true, '[5, 10].overlaps(\'[10, 11]\') is true')
+  t(parse('[5, 10)', x => parseInt(x)).overlaps(parse('[8, 9]', x => parseInt(x))), true, '[5, 10).overlaps(\'[8, 9]\') is true')
+  t(parse('[8, 9)', x => parseInt(x)).overlaps(parse('[5, 10]', x => parseInt(x))), true, '[8, 9).overlaps(\'[5, 10]\') is true')
+  t(parse('[12, 20)', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), false, '[12, 20).overlaps(\'[10, 11]\') is false')
+
+  t(parse('(5, 10)', x => parseInt(x)).adjacentTo(parse('(10, 20)', x => parseInt(x))), true, '(5, 10).adjacentTo(\'(10, 20]\') is true')
+  t(parse('(5, 10]', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 10].adjacentTo(\'[10, 20]\') is false')
+  t(parse('(5, 5)', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 5].adjacentTo(\'[10, 20]\') is false')
 })

--- a/index.test.js
+++ b/index.test.js
@@ -93,7 +93,7 @@ describe('roundtrip', function () {
   trip('[0,1)')
 })
 
-describe('Range', function () {
+describe('Range: boolean methods', function () {
   t(parse('[1, 10)', x => parseInt(x)).containsPoint(5), true, '[1, 10).containsPoint(5) is true')
   t(parse('[1, 10)', x => parseInt(x)).containsPoint(-5), false, '[1, 10).containsPoint(-5) is false')
 
@@ -111,20 +111,66 @@ describe('Range', function () {
 
   t(parse('empty', x => parseInt(x)).strictlyRightOf(parse('[5, 10)', x => parseInt(x))), false, 'empty.strictlyRightOf(\'[5, 10)\') is false')
   t(parse('[5, 10)', x => parseInt(x)).strictlyRightOf(parse('empty', x => parseInt(x))), false, '[5, 10).strictlyRightOf(\'empty\') is false')
-  t(parse('[20, 30)', x => parseInt(x)).strictlyRightOf(parse('(5,)', x => parseInt(x))), false, '[20, 30).strictlyLeftOf(\'(5,)\') is false')
-  t(parse('(,30)', x => parseInt(x)).strictlyRightOf(parse('[5, 10)', x => parseInt(x))), false, '(, 30).strictlyLeftOf(\'[5, 10)\') is false')
+  t(parse('[20, 30)', x => parseInt(x)).strictlyRightOf(parse('(5,)', x => parseInt(x))), false, '[20, 30).strictlyRightOf(\'(5,)\') is false')
+  t(parse('(,30)', x => parseInt(x)).strictlyRightOf(parse('[5, 10)', x => parseInt(x))), false, '(, 30).strictlyRightOf(\'[5, 10)\') is false')
   t(parse('[30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30)', x => parseInt(x))), true, '[30, 40).strictlyRightOf(\'[20, 30)\') is true')
   t(parse('(30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), true, '(30, 40).strictlyRightOf(\'[20, 30]\') is true')
   t(parse('[30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), false, '[30, 40).strictlyRightOf(\'[20, 30]\') is false')
   t(parse('[50, 60)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), true, '[50, 60).strictlyRightOf(\'[20, 30]\') is false')
 
+  t(parse('(10, 20)', x => parseInt(x)).extendsLeftOf(parse('(15, 30)', x => parseInt(x))), true, '(10, 20).extendsLeftOf(\'(15, 30)\') is true')
+  t(parse('(10, 20)', x => parseInt(x)).extendsLeftOf(parse('(10, 20)', x => parseInt(x))), false, '(10, 20).extendsLeftOf(\'(10, 20)\') is false')
+  t(parse('[10, 20)', x => parseInt(x)).extendsLeftOf(parse('(10, 20)', x => parseInt(x))), true, '[10, 20).extendsLeftOf(\'(10, 20)\') is true')
+
+  t(parse('(10, 20)', x => parseInt(x)).extendsRightOf(parse('(10, 15)', x => parseInt(x))), true, '(10, 20).extendsRightOf(\'(10, 15)\') is true')
+  t(parse('(10, 20)', x => parseInt(x)).extendsRightOf(parse('(10, 20)', x => parseInt(x))), false, '(10, 20).extendsRightOf(\'(10, 20)\') is false')
+  t(parse('(10, 20]', x => parseInt(x)).extendsRightOf(parse('(10, 20)', x => parseInt(x))), true, '(10, 20].extendsRightOf(\'(10, 20)\') is true')
+
+  t(parse('[5, 10)', x => parseInt(x)).overlaps(parse('empty', x => parseInt(x))), false, '[5, 10).overlaps(\'emtpy\') is false')
+  t(parse('empty', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), false, 'empty.overlaps(\'[10, 11]\') is false')
   t(parse('[5, 10)', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), false, '[5, 10).overlaps(\'[10, 11]\') is false')
   t(parse('[5, 10]', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), true, '[5, 10].overlaps(\'[10, 11]\') is true')
   t(parse('[5, 10)', x => parseInt(x)).overlaps(parse('[8, 9]', x => parseInt(x))), true, '[5, 10).overlaps(\'[8, 9]\') is true')
   t(parse('[8, 9)', x => parseInt(x)).overlaps(parse('[5, 10]', x => parseInt(x))), true, '[8, 9).overlaps(\'[5, 10]\') is true')
   t(parse('[12, 20)', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), false, '[12, 20).overlaps(\'[10, 11]\') is false')
+  t(parse('(0, 3)', x => parseInt(x)).overlaps(parse('(3, 4)', x => parseInt(x))), false, '(0, 3).overlaps(\'(3, 4)\') is false')
 
-  t(parse('(5, 10)', x => parseInt(x)).adjacentTo(parse('(10, 20)', x => parseInt(x))), true, '(5, 10).adjacentTo(\'(10, 20]\') is true')
-  t(parse('(5, 10]', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 10].adjacentTo(\'[10, 20]\') is false')
-  t(parse('(5, 5)', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 5].adjacentTo(\'[10, 20]\') is false')
+  t(parse('empty', x => parseInt(x)).adjacentTo(parse('empty', x => parseInt(x))), false, 'empty.adjacentTo(\'empty\') is false')
+  t(parse('(5, 10)', x => parseInt(x)).adjacentTo(parse('(10, 20)', x => parseInt(x))), false, '(5, 10).adjacentTo(\'(10, 20)\') is false')
+  t(parse('(5, 10]', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 10].adjacentTo(\'[10, 20)\') is false')
+  t(parse('(5, 10)', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), true, '(5, 10).adjacentTo(\'[10, 20)\') is true')
+  t(parse('(5, 9)', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 9).adjacentTo(\'[10, 20)\') is false')
+})
+
+describe('Range: range methods', function () {
+  t(parse('empty', x => parseInt(x)).union(parse('empty', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), 'empty.union(\'empty\') is empty')
+  t(parse('(0, 3)', x => parseInt(x)).union(parse('empty', x => parseInt(x))), new Range(0, 3, 0), '(0, 3).union(\'empty\') is (0, 3)')
+  t(parse('empty', x => parseInt(x)).union(parse('(0, 3)', x => parseInt(x))), new Range(0, 3, 0), 'emtpy.union(\'(0, 3)\') is (0, 3)')
+  t(parse('(0, 3)', x => parseInt(x)).union(parse('[3, 4)', x => parseInt(x))), new Range(0, 4, 0), '(0, 3).union(\'[3, 4)\') is (0, 4)')
+  t(parse('[0, 10)', x => parseInt(x)).union(parse('[10, 20)', x => parseInt(x))), new Range(0, 20, RANGE_LB_INC), '[0, 10).union(\'[10, 20)\') is [0, 20)')
+  t(parse('(0, 10)', x => parseInt(x)).union(parse('[0, 20]', x => parseInt(x))), new Range(0, 20, 0 | RANGE_LB_INC | RANGE_UB_INC), '(0, 10).union(\'[0, 20]\') is [0, 20]')
+  t(parse('(,20]', x => parseInt(x)).union(parse('(0, 20]', x => parseInt(x))), new Range(null, 20, 0 | RANGE_UB_INC | RANGE_LB_INF), '(,20].union(\'(0, 20]\') is (,20]')
+  t(parse('(0,)', x => parseInt(x)).union(parse('(5, 20)', x => parseInt(x))), new Range(0, null, RANGE_UB_INF), '(0,).union(\'(5, 20)\') is (0,)')
+
+  t(parse('empty', x => parseInt(x)).intersection(parse('empty', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), 'empty.intersection(\'empty\') is empty')
+  t(parse('(0, 3)', x => parseInt(x)).intersection(parse('empty', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), '(0, 3).intersection(\'empty\') is (0, 3)')
+  t(parse('empty', x => parseInt(x)).intersection(parse('(0, 3)', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), 'empty.intersection(\'(0, 3)\') is empty')
+  t(parse('(0,)', x => parseInt(x)).intersection(parse('(3,)', x => parseInt(x))), new Range(3, null, RANGE_UB_INF), '(0,).intersection(\'(3,)\') is (3,)')
+  t(parse('(,3)', x => parseInt(x)).intersection(parse('(,6)', x => parseInt(x))), new Range(null, 3, RANGE_LB_INF), '(,3).intersection(\'(,6)\') is (,3)')
+  t(parse('(0, 20]', x => parseInt(x)).intersection(parse('(10, 20]', x => parseInt(x))), new Range(10, 20, RANGE_UB_INC), '(0, 20].intersection(\'(10, 20]\') is (10, 20]')
+
+  t(parse('empty', x => parseInt(x)).difference(parse('empty', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), 'empty.difference(\'empty\') is empty')
+  t(parse('(0, 4)', x => parseInt(x)).difference(parse('(2, 6)', x => parseInt(x))), new Range(0, 2, RANGE_UB_INC), '(0, 4).difference(\'(2, 6)\') is (0, 2]')
+  t(parse('(0, 4]', x => parseInt(x)).difference(parse('[2, 6)', x => parseInt(x))), new Range(0, 2, 0), '(0, 4).difference(\'[2, 6)\') is (0, 2)')
+  t(parse('(2, 6)', x => parseInt(x)).difference(parse('(0, 4)', x => parseInt(x))), new Range(4, 6, RANGE_LB_INC), '(2, 6).difference(\'(0, 4)\') is [4, 6)')
+  t(parse('(2, 6)', x => parseInt(x)).difference(parse('(0, 4]', x => parseInt(x))), new Range(4, 6, 0), '(2, 6).difference(\'(0, 4)\') is (4, 6)')
+  t(parse('(0, 3)', x => parseInt(x)).difference(parse('(3, 4)', x => parseInt(x))), new Range(0, 3, 0), '(0, 3).difference(\'(3, 4)\') is (0, 3)')
+
+  t(parse('(0,)', x => parseInt(x)).difference(parse('[3,)', x => parseInt(x))), new Range(0, 3, 0), '(0,).difference(\'(3,)\') is (0, 3)')
+  t(parse('(,100)', x => parseInt(x)).difference(parse('(,50]', x => parseInt(x))), new Range(50, 100, 0), '(,100).difference(\'(,50]\') is (50, 100)')
+
+  t(parse('(,100)', x => parseInt(x)).difference(parse('(50,)', x => parseInt(x))), new Range(null, 50, RANGE_LB_INF | RANGE_UB_INC), '(, 100).difference(\'(50, )\') is (, 50')
+  t(parse('(100,)', x => parseInt(x)).difference(parse('(,150)', x => parseInt(x))), new Range(150, null, RANGE_UB_INF | RANGE_LB_INC), '(100,).difference(\'(,150)\') is [150,)')
+
+  t(parse('(-infinity,infinity)', x => parseInt(x)).difference(parse('(-infinity,infinity)', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), '(-infinity,infinity).difference(\'(-infinity,infinity)\') is empty')
 })

--- a/index.test.js
+++ b/index.test.js
@@ -108,6 +108,7 @@ describe('Range: boolean methods', function () {
   t(parse('[5, 9]', x => parseInt(x)).strictlyLeftOf(parse('(9, 11)', x => parseInt(x))), true, '[5, 9].strictlyLeftOf(\'[(9, 11)\') is true')
   t(parse('[5, 9]', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), false, '[5, 9].strictlyLeftOf(\'[9, 11)\') is false')
   t(parse('[5, 10)', x => parseInt(x)).strictlyLeftOf(parse('[9, 11)', x => parseInt(x))), false, '[5, 10).strictlyLeftOf(\'[9, 11)\') is false')
+  t(parse('(-infinity,infinity)', x => parseInt(x)).strictlyLeftOf(parse('(-infinity,infinity)', x => parseInt(x))), false, '(-infinity,infinity).strictlyLeftOf(\'(-infinity,infinity)\') is false')
 
   t(parse('empty', x => parseInt(x)).strictlyRightOf(parse('[5, 10)', x => parseInt(x))), false, 'empty.strictlyRightOf(\'[5, 10)\') is false')
   t(parse('[5, 10)', x => parseInt(x)).strictlyRightOf(parse('empty', x => parseInt(x))), false, '[5, 10).strictlyRightOf(\'empty\') is false')
@@ -117,14 +118,25 @@ describe('Range: boolean methods', function () {
   t(parse('(30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), true, '(30, 40).strictlyRightOf(\'[20, 30]\') is true')
   t(parse('[30, 40)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), false, '[30, 40).strictlyRightOf(\'[20, 30]\') is false')
   t(parse('[50, 60)', x => parseInt(x)).strictlyRightOf(parse('[20, 30]', x => parseInt(x))), true, '[50, 60).strictlyRightOf(\'[20, 30]\') is false')
+  t(parse('(-infinity,infinity)', x => parseInt(x)).strictlyRightOf(parse('(-infinity,infinity)', x => parseInt(x))), false, '(-infinity,infinity).strictlyLeftOf(\'(-infinity,infinity)\') is false')
 
+  t(parse('empty', x => parseInt(x)).extendsLeftOf(parse('empty', x => parseInt(x))), false, 'emtpy.extendsLeftOf(\'empty\') is false')
+  t(parse('(10, 20)', x => parseInt(x)).extendsLeftOf(parse('empty', x => parseInt(x))), false, '(10, 20).extendsLeftOf(\'empty\') is false')
   t(parse('(10, 20)', x => parseInt(x)).extendsLeftOf(parse('(15, 30)', x => parseInt(x))), true, '(10, 20).extendsLeftOf(\'(15, 30)\') is true')
   t(parse('(10, 20)', x => parseInt(x)).extendsLeftOf(parse('(10, 20)', x => parseInt(x))), false, '(10, 20).extendsLeftOf(\'(10, 20)\') is false')
   t(parse('[10, 20)', x => parseInt(x)).extendsLeftOf(parse('(10, 20)', x => parseInt(x))), true, '[10, 20).extendsLeftOf(\'(10, 20)\') is true')
+  t(parse('(,20)', x => parseInt(x)).extendsLeftOf(parse('(10, 20)', x => parseInt(x))), true, '(, 20).extendsLeftOf(\'(10, 20)\') is true')
+  t(parse('(,20)', x => parseInt(x)).extendsLeftOf(parse('(, 20)', x => parseInt(x))), false, '(, 20).extendsLeftOf(\'(, 20)\') is false')
+  t(parse('(-infinity,infinity)', x => parseInt(x)).extendsLeftOf(parse('(-infinity,infinity)', x => parseInt(x))), false, '(-infinity,infinity).extendsLeftOf(\'(-infinity,infinity)\') is false')
 
+  t(parse('empty', x => parseInt(x)).extendsRightOf(parse('empty', x => parseInt(x))), false, 'emtpy.extendsRightOf(\'empty\') is false')
+  t(parse('(10, 20)', x => parseInt(x)).extendsRightOf(parse('empty', x => parseInt(x))), false, '(10, 20).extendsRightOf(\'empty\') is false')
   t(parse('(10, 20)', x => parseInt(x)).extendsRightOf(parse('(10, 15)', x => parseInt(x))), true, '(10, 20).extendsRightOf(\'(10, 15)\') is true')
   t(parse('(10, 20)', x => parseInt(x)).extendsRightOf(parse('(10, 20)', x => parseInt(x))), false, '(10, 20).extendsRightOf(\'(10, 20)\') is false')
   t(parse('(10, 20]', x => parseInt(x)).extendsRightOf(parse('(10, 20)', x => parseInt(x))), true, '(10, 20].extendsRightOf(\'(10, 20)\') is true')
+  t(parse('(20,)', x => parseInt(x)).extendsRightOf(parse('(10, 20)', x => parseInt(x))), true, '(20, ).extendsRightOf(\'(10, 20)\') is true')
+  t(parse('(20,)', x => parseInt(x)).extendsRightOf(parse('(20,)', x => parseInt(x))), false, '(20,).extendsRightOf(\'(20,)\') is false')
+  t(parse('(-infinity,infinity)', x => parseInt(x)).extendsRightOf(parse('(-infinity,infinity)', x => parseInt(x))), false, '(-infinity,infinity).extendsRightOf(\'(-infinity,infinity)\') is false')
 
   t(parse('[5, 10)', x => parseInt(x)).overlaps(parse('empty', x => parseInt(x))), false, '[5, 10).overlaps(\'emtpy\') is false')
   t(parse('empty', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), false, 'empty.overlaps(\'[10, 11]\') is false')
@@ -134,12 +146,17 @@ describe('Range: boolean methods', function () {
   t(parse('[8, 9)', x => parseInt(x)).overlaps(parse('[5, 10]', x => parseInt(x))), true, '[8, 9).overlaps(\'[5, 10]\') is true')
   t(parse('[12, 20)', x => parseInt(x)).overlaps(parse('[10, 11]', x => parseInt(x))), false, '[12, 20).overlaps(\'[10, 11]\') is false')
   t(parse('(0, 3)', x => parseInt(x)).overlaps(parse('(3, 4)', x => parseInt(x))), false, '(0, 3).overlaps(\'(3, 4)\') is false')
+  t(parse('(0,)', x => parseInt(x)).overlaps(parse('(100, 200)', x => parseInt(x))), true, '(0,).overlaps(\'(100, 200)\') is true')
+  t(parse('(,100)', x => parseInt(x)).overlaps(parse('(1, 2)', x => parseInt(x))), true, '(,100).overlaps(\'(1, 2)\') is true')
+  t(parse('(-infinity,infinity)', x => parseInt(x)).overlaps(parse('(-infinity,infinity)', x => parseInt(x))), true, '(-infinity,infinity).overlaps(\'(-infinity,infinity)\') is true')
 
   t(parse('empty', x => parseInt(x)).adjacentTo(parse('empty', x => parseInt(x))), false, 'empty.adjacentTo(\'empty\') is false')
   t(parse('(5, 10)', x => parseInt(x)).adjacentTo(parse('(10, 20)', x => parseInt(x))), false, '(5, 10).adjacentTo(\'(10, 20)\') is false')
   t(parse('(5, 10]', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 10].adjacentTo(\'[10, 20)\') is false')
   t(parse('(5, 10)', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), true, '(5, 10).adjacentTo(\'[10, 20)\') is true')
   t(parse('(5, 9)', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), false, '(5, 9).adjacentTo(\'[10, 20)\') is false')
+  t(parse('(,10)', x => parseInt(x)).adjacentTo(parse('[10, 20)', x => parseInt(x))), true, '(, 10).adjacentTo(\'[10, 20)\') is true')
+  t(parse('(20,)', x => parseInt(x)).adjacentTo(parse('(10, 20]', x => parseInt(x))), true, '(20,).adjacentTo(\'(10, 20]\') is true')
 })
 
 describe('Range: range methods', function () {
@@ -151,6 +168,7 @@ describe('Range: range methods', function () {
   t(parse('(0, 10)', x => parseInt(x)).union(parse('[0, 20]', x => parseInt(x))), new Range(0, 20, 0 | RANGE_LB_INC | RANGE_UB_INC), '(0, 10).union(\'[0, 20]\') is [0, 20]')
   t(parse('(,20]', x => parseInt(x)).union(parse('(0, 20]', x => parseInt(x))), new Range(null, 20, 0 | RANGE_UB_INC | RANGE_LB_INF), '(,20].union(\'(0, 20]\') is (,20]')
   t(parse('(0,)', x => parseInt(x)).union(parse('(5, 20)', x => parseInt(x))), new Range(0, null, RANGE_UB_INF), '(0,).union(\'(5, 20)\') is (0,)')
+  t(parse('(-infinity,infinity)', x => parseInt(x)).union(parse('(-infinity,infinity)', x => parseInt(x))), new Range(null, null, RANGE_LB_INF | RANGE_UB_INF), '(-infinity,infinity).union(\'(-infinity,infinity)\') is (-infinity,infinity)')
 
   t(parse('empty', x => parseInt(x)).intersection(parse('empty', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), 'empty.intersection(\'empty\') is empty')
   t(parse('(0, 3)', x => parseInt(x)).intersection(parse('empty', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), '(0, 3).intersection(\'empty\') is (0, 3)')
@@ -158,6 +176,7 @@ describe('Range: range methods', function () {
   t(parse('(0,)', x => parseInt(x)).intersection(parse('(3,)', x => parseInt(x))), new Range(3, null, RANGE_UB_INF), '(0,).intersection(\'(3,)\') is (3,)')
   t(parse('(,3)', x => parseInt(x)).intersection(parse('(,6)', x => parseInt(x))), new Range(null, 3, RANGE_LB_INF), '(,3).intersection(\'(,6)\') is (,3)')
   t(parse('(0, 20]', x => parseInt(x)).intersection(parse('(10, 20]', x => parseInt(x))), new Range(10, 20, RANGE_UB_INC), '(0, 20].intersection(\'(10, 20]\') is (10, 20]')
+  t(parse('(-infinity,infinity)', x => parseInt(x)).intersection(parse('(-infinity,infinity)', x => parseInt(x))), new Range(null, null, RANGE_LB_INF | RANGE_UB_INF), '(-infinity,infinity).intersection(\'(-infinity,infinity)\') is (-infinity,infinity)')
 
   t(parse('empty', x => parseInt(x)).difference(parse('empty', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), 'empty.difference(\'empty\') is empty')
   t(parse('(0, 4)', x => parseInt(x)).difference(parse('(2, 6)', x => parseInt(x))), new Range(0, 2, RANGE_UB_INC), '(0, 4).difference(\'(2, 6)\') is (0, 2]')
@@ -165,12 +184,9 @@ describe('Range: range methods', function () {
   t(parse('(2, 6)', x => parseInt(x)).difference(parse('(0, 4)', x => parseInt(x))), new Range(4, 6, RANGE_LB_INC), '(2, 6).difference(\'(0, 4)\') is [4, 6)')
   t(parse('(2, 6)', x => parseInt(x)).difference(parse('(0, 4]', x => parseInt(x))), new Range(4, 6, 0), '(2, 6).difference(\'(0, 4)\') is (4, 6)')
   t(parse('(0, 3)', x => parseInt(x)).difference(parse('(3, 4)', x => parseInt(x))), new Range(0, 3, 0), '(0, 3).difference(\'(3, 4)\') is (0, 3)')
-
   t(parse('(0,)', x => parseInt(x)).difference(parse('[3,)', x => parseInt(x))), new Range(0, 3, 0), '(0,).difference(\'(3,)\') is (0, 3)')
   t(parse('(,100)', x => parseInt(x)).difference(parse('(,50]', x => parseInt(x))), new Range(50, 100, 0), '(,100).difference(\'(,50]\') is (50, 100)')
-
   t(parse('(,100)', x => parseInt(x)).difference(parse('(50,)', x => parseInt(x))), new Range(null, 50, RANGE_LB_INF | RANGE_UB_INC), '(, 100).difference(\'(50, )\') is (, 50')
   t(parse('(100,)', x => parseInt(x)).difference(parse('(,150)', x => parseInt(x))), new Range(150, null, RANGE_UB_INF | RANGE_LB_INC), '(100,).difference(\'(,150)\') is [150,)')
-
   t(parse('(-infinity,infinity)', x => parseInt(x)).difference(parse('(-infinity,infinity)', x => parseInt(x))), new Range(null, null, RANGE_EMPTY), '(-infinity,infinity).difference(\'(-infinity,infinity)\') is empty')
 })


### PR DESCRIPTION
Per issue https://github.com/martianboy/postgres-range/issues/5

Added `strictlyLeftOf`, `strictlyRightOf`, `extendsLeftOf`, `extendsRightOf`, `overlaps`, `adjacentTo`, `union`, `intersection` and `difference`. This makes the package more aligned - though not an exact a mirror of - the psql function listed here https://www.postgresql.org/docs/9.4/functions-range.html.

I have added test cases, but it would probably be good to review and notify me of any edge cases I missed. Additionally, I'm sure there is room for optimization, but I figure functionality comes first.